### PR TITLE
Remove the "lib" prefix in CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ endif(WIN32)
 #add library and link
 add_library(cimgui SHARED ${IMGUI_SOURCES})
 target_link_libraries(cimgui ${IMGUI_LIBRARIES})
+set_target_properties(cimgui PROPERTIES PREFIX "")
 
 #install
 install(TARGETS cimgui


### PR DESCRIPTION
After doing this, I noticed that there is still a Makefile in the repository, which already uses the old "cimgui.so/dylib" naming. In any case, this PR just fixes CMakeLists so it generates libraries without the "lib" prefix.