### PR TITLE
Link to ApplicationServices.framework on macOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@ else (IMGUI_STATIC)
 endif (IMGUI_STATIC)
 
 target_link_libraries(cimgui ${IMGUI_LIBRARIES})
+if (APPLE)
+	target_link_libraries(cimgui "-framework ApplicationServices")
+endif()
 set_target_properties(cimgui PROPERTIES PREFIX "")
 
 #install


### PR DESCRIPTION
I'm not able to build on macOS without linking against ApplicationServices.framework. This seems to be related to this imgui PR: https://github.com/ocornut/imgui/pull/2546. This shouldn't affect any other build configs as it's behind an `if (APPLE)` conditional.