### PR TITLE
fix IMGUI_IMPL_API CMake define; add option to specify impls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.1)
 
 project(cimgui)
 
+set(IMGUI_IMPL_FILES "" CACHE STRING "Implementation files to build (selection of imgui/examples/imgui_impl_*.cpp)")
+
 #general settings
 file(GLOB IMGUI_SOURCES
     cimgui.cpp
@@ -9,6 +11,8 @@ file(GLOB IMGUI_SOURCES
     imgui/imgui_draw.cpp
     imgui/imgui_demo.cpp
     imgui/imgui_widgets.cpp
+
+    ${IMGUI_IMPL_FILES}
 )
 
 set(IMGUI_STATIC "no" CACHE STRING "Build as a static library")
@@ -20,11 +24,12 @@ else (IMGUI_STATIC)
     add_library(cimgui SHARED ${IMGUI_SOURCES})
 endif (IMGUI_STATIC)
 
+target_compile_options(cimgui PUBLIC -fno-exceptions -fno-rtti)
 target_compile_definitions(cimgui PUBLIC IMGUI_DISABLE_OBSOLETE_FUNCTIONS=1)
 if (WIN32)
-    target_compile_definitions(cimgui PUBLIC IMGUI_IMPL_API="extern \"C\" __declspec\(dllexport\)")
+    target_compile_definitions(cimgui PUBLIC "IMGUI_IMPL_API=extern \"C\" __declspec\(dllexport\)")
 else (WIN32)
-    target_compile_definitions(cimgui PUBLIC IMGUI_IMPL_API="extern \"C\" ")
+    target_compile_definitions(cimgui PUBLIC "IMGUI_IMPL_API=extern \"C\" ")
 endif (WIN32)
 
 target_include_directories(cimgui PUBLIC ${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
the old define was causing issues for me on Linux (double escaping the quotes, causing compiler errors).