### PR TITLE
Add CimguiStorage and ImGuiPlatformIO redirect functions to the master branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Notes:
 * edit config_generator.lua for adding includes needed by your chosen implementations.
 * Run generator.bat or generator.sh with gcc, clang or cl and LuaJIT on your PATH.
 * as a result some files are generated: `cimgui.cpp` and `cimgui.h` for compiling and some lua/json files with information about the binding: `definitions.json` with function info, `structs_and_enums.json` with struct and enum info, `impl_definitions.json` with functions from the implementations info. 
+* If you are generating bindings for the [docking](https://github.com/ocornut/imgui/tree/docking) branch of imgui, you must define the `IMGUI_DOCKING` constant in CMakeLists.txt. This includes extra custom definitions that are needed for some functionality on the docking branch.
 
 # generate binding
 * C interface is exposed by cimgui.h when you define CIMGUI_DEFINE_ENUMS_AND_STRUCTS


### PR DESCRIPTION
In an effort to keep things compatible and usable with the docking branch, I've moved this code into the current master branch. This code is needed to enable the viewport feature. It is hidden behind an `IMGUI_DOCKING` define, which should be defined in the docking branch, but will otherwise be disabled on the master branch, making this change a no-op for most people.

There is more substantial discussion about this in https://github.com/cimgui/cimgui/issues/71. Nothing significant has changed in the current docking branch around this problem from what I can tell.