### PR TITLE
Altering the exported 'include' directory path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,8 @@ else (WIN32)
     target_compile_definitions(cimgui PUBLIC IMGUI_IMPL_API="extern \"C\" ")
 endif (WIN32)
 
-target_include_directories(cimgui PUBLIC ${CMAKE_SOURCE_DIR})
-target_include_directories(cimgui PUBLIC ${CMAKE_SOURCE_DIR}/imgui)
+target_include_directories(cimgui PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(cimgui PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/imgui)
 set_target_properties(cimgui PROPERTIES PREFIX "")
 
 #install


### PR DESCRIPTION
Altering the exported 'include' directory path so that it is not mistakenly set to a user's project root path.  This will allow users who are linking to cimgui from a nested directory to be provided with the correct 'include' paths automatically.

Presently, if a user's project is structured as shown below, then the 'include' path that is propagated upward upon linking to the `cimgui` target will **not** reflect the actual absolute path of the header files.

```
/home/user/my_project
|_CMakeLists.txt
\_lib/
   \_cimgui/
      \_CMakeLists.txt
      |_include/
```

Before this commit, a target linking to `cimgui` in /home/user/my_project/CMakeLists.txt will have `/home/user/my_project/` and `/home/user/my_project/imgui` added to its include-flags.  This is obviously undesirable.

After this commit, that top-level target will correctly receive `/home/user/my_project/lib/cimgui` and `/home/user/my_project/cimgui/imgui` in its include-flags.