### PR TITLE
Make names visible when using gcc/clang

### DIFF
--- a/cimgui.h
+++ b/cimgui.h
@@ -15,7 +15,11 @@
     #define snprintf sprintf_s
     #endif
 #else
-    #define API
+    #ifdef __GNUC__
+        #define API  __attribute__((__visibility__("default")))
+    #else
+        #define API
+    #endif
 #endif
 
 #if defined __cplusplus

--- a/generator/cimgui_template.h
+++ b/generator/cimgui_template.h
@@ -12,7 +12,11 @@
     #define snprintf sprintf_s
     #endif
 #else
-    #define API
+    #ifdef __GNUC__
+        #define API  __attribute__((__visibility__("default")))
+    #else
+        #define API
+    #endif
 #endif
 
 #if defined __cplusplus

--- a/generator/output/cimgui.h
+++ b/generator/output/cimgui.h
@@ -15,7 +15,11 @@
     #define snprintf sprintf_s
     #endif
 #else
-    #define API
+    #ifdef __GNUC__
+        #define API  __attribute__((__visibility__("default")))
+    #else
+        #define API
+    #endif
 #endif
 
 #if defined __cplusplus


### PR DESCRIPTION
I had an issue with missing names when including cimgui.c/h in a project that created somelibrary.so
This patch fixes the issue