### PR TITLE
Make git commands in README.md code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Notes:
 # compilation
 
 * clone 
-  * git clone --recursive https://github.com/cimgui/cimgui.git
-  * git submodule update
+  * `git clone --recursive https://github.com/cimgui/cimgui.git`
+  * `git submodule update`
 * compile 
   * using makefile on linux/macOS/mingw (Or use CMake to generate project)
   * cmake options are IMGUI_STATIC (compiling as static library), IMGUI_FREETYPE (for using Freetype2) and FREETYPE_PATH (Freetype2 cmake install location)


### PR DESCRIPTION
This way they can be copied and `https://github.com/cimgui/cimgui.git` won't be shortened to `cimgui/cimgui.git`.