### PR TITLE
Make backend_test compatible with Windows

### DIFF
--- a/backend_test/main.c
+++ b/backend_test/main.c
@@ -1,4 +1,7 @@
 #define CIMGUI_DEFINE_ENUMS_AND_STRUCTS
+#ifdef _WIN32
+#include <windows.h>
+#endif
 #include "cimgui.h"
 #include "cimgui_extras.h"
 #include "cimgui_impl.h"


### PR DESCRIPTION
GL headers need to include windows.h