### PR TITLE
Change Examples to Backends

### DIFF
--- a/generator/generator.lua
+++ b/generator/generator.lua
@@ -405,7 +405,7 @@ if #implementations > 0 then
 	local config = require"config_generator"
     
     for i,impl in ipairs(implementations) do
-        local source = [[../imgui/examples/imgui_impl_]].. impl .. ".h "
+        local source = [[../imgui/backends/imgui_impl_]].. impl .. ".h "
         local locati = [[imgui_impl_]].. impl
 
 		local define_cmd = COMPILER=="cl" and [[ /E /D]] or [[ -E -D]]


### PR DESCRIPTION
Dear Imgui just moved all `imgui_impl_XXXX` files to the `backends/` directory.

In order for the generator to keep working this change needs to be ported to `generator.lua` and maybe in other files too...

Note: build will fail unless using latest HEAD from imgui.