### PR TITLE
Adding CFLAGS to generator.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Notes:
 * edit config_generator.lua for adding includes needed by your chosen backends (vulkan needs that).
 * Run generator.bat or generator.sh with gcc, clang or cl and LuaJIT on your PATH.
 * as a result some files are generated: `cimgui.cpp`, `cimgui.h` and `cimgui_impl.h` for compiling and some lua/json files with information about the binding: `definitions.json` with function info, `structs_and_enums.json` with struct and enum info, `impl_definitions.json` with functions from the backends info. 
-* You can pass compiler flags to generator.sh or generator.bat at the end ofthe call to further specify the compiler behavior. (e.g. -DIMGUI_USER_CONFIG or -DIMGUI_USE_WCHAR32)
+* You can pass compiler flags to generator.sh or generator.bat at the end of the call to further specify the compiler behavior. (e.g. -DIMGUI_USER_CONFIG or -DIMGUI_USE_WCHAR32)
 
 # generate binding
 * C interface is exposed by cimgui.h when you define CIMGUI_DEFINE_ENUMS_AND_STRUCTS

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Notes:
 
 # using generator
 
+```
 * this is only needed (before compilation) if you want an imgui version different from the one provided, otherwise generation is already done.
 * you will need LuaJIT (https://github.com/LuaJIT/LuaJIT.git better 2.1 branch) or precompiled for linux/macOS/windows in https://luapower.com/luajit/download
 * you need to use also a C++ compiler for doing preprocessing: gcc (In windows MinGW-W64-builds for example), clang or cl (MSVC). (this repo was done with gcc)
@@ -40,6 +41,7 @@ Notes:
 * edit config_generator.lua for adding includes needed by your chosen backends (vulkan needs that).
 * Run generator.bat or generator.sh with gcc, clang or cl and LuaJIT on your PATH.
 * as a result some files are generated: `cimgui.cpp`, `cimgui.h` and `cimgui_impl.h` for compiling and some lua/json files with information about the binding: `definitions.json` with function info, `structs_and_enums.json` with struct and enum info, `impl_definitions.json` with functions from the backends info. 
+* You can pass compiler flags to generator.sh or generator.bat at the end ofthe call to further specify the compiler behavior. (e.g. -DIMGUI_USER_CONFIG or -DIMGUI_USE_WCHAR32)
 
 # generate binding
 * C interface is exposed by cimgui.h when you define CIMGUI_DEFINE_ENUMS_AND_STRUCTS

--- a/generator/generator.bat
+++ b/generator/generator.bat
@@ -17,7 +17,7 @@ set PATH=%PATH%;C:\anima;C:\mingws\i686-7.2.0-release-posix-dwarf-rt_v5-rev1\min
 :: arg[1] compiler name gcc, clang or cl
 :: arg[2] options as words in one string: internal for imgui_internal generation, freetype for freetype generation
 :: examples: "" "internal" "internal freetype"
-:: arg[3..n] name of implementations to generate and/or CLFLAGS (e.g. -DIMGUI_USER_CONFIG or -DIMGUI_USE_WCHAR32)
+:: arg[3..n] name of implementations to generate and/or CFLAGS (e.g. -DIMGUI_USER_CONFIG or -DIMGUI_USE_WCHAR32)
 luajit ./generator.lua gcc "internal" glfw opengl3 opengl2 sdl
 
 ::leave console open

--- a/generator/generator.bat
+++ b/generator/generator.bat
@@ -17,7 +17,7 @@ set PATH=%PATH%;C:\anima;C:\mingws\i686-7.2.0-release-posix-dwarf-rt_v5-rev1\min
 :: arg[1] compiler name gcc, clang or cl
 :: arg[2] options as words in one string: internal for imgui_internal generation, freetype for freetype generation
 :: examples: "" "internal" "internal freetype"
-:: arg[3..n] name of implementations to generate
+:: arg[3..n] name of implementations to generate and/or CLFLAGS (e.g. -DIMGUI_USER_CONFIG or -DIMGUI_USE_WCHAR32)
 luajit ./generator.lua gcc "internal" glfw opengl3 opengl2 sdl
 
 ::leave console open

--- a/generator/generator.lua
+++ b/generator/generator.lua
@@ -13,7 +13,7 @@ local CPRE,CTEST
 --get implementations
 local implementations = {}
 for i=3,#script_args do
-    if script_args[i]:match("^[-/]") then
+    if script_args[i]:match(COMPILER == cl and "^/" or "^%-") then
         local key, value = script_args[i]:match("^(.+)=(.+)$")
         if key and value then
             CFLAGS = CFLAGS .. " " .. key .. "=\"" .. value:gsub("\"", "\\\"") .. "\"";

--- a/generator/generator.lua
+++ b/generator/generator.lua
@@ -8,6 +8,7 @@ local script_args = {...}
 local COMPILER = script_args[1]
 local INTERNAL_GENERATION = script_args[2]:match("internal") and true or false
 local FREETYPE_GENERATION = script_args[2]:match("freetype") and true or false
+local CFLAGS = ""
 local CPRE,CTEST
 if COMPILER == "gcc" or COMPILER == "clang" then
     CPRE = COMPILER..[[ -E -DIMGUI_DISABLE_OBSOLETE_FUNCTIONS -DIMGUI_API="" -DIMGUI_IMPL_API="" ]]
@@ -44,7 +45,18 @@ print("INTERNAL_GENERATION",INTERNAL_GENERATION)
 print("FREETYPE_GENERATION",FREETYPE_GENERATION)
 --get implementations
 local implementations = {}
-for i=3,#script_args do table.insert(implementations,script_args[i]) end
+for i=3,#script_args do
+    if script_args[i]:match("^%-") then
+        local key, value = script_args[i]:match("^(.+)=(.+)$")
+        if key and value then
+            CFLAGS = CFLAGS .. " " .. key .. "=\"" .. value:gsub("\"", "\\\"") .. "\"";
+        else
+            CFLAGS = CFLAGS .. " " .. script_args[i]
+        end
+    else
+        table.insert(implementations,script_args[i])
+    end
+end
 
 --------------------------------------------------------------------------
 --this table has the functions to be skipped in generation
@@ -335,7 +347,6 @@ end
 print("IMGUI_VERSION",imgui_version)
 --get some defines----------------------------
 gdefines = get_defines{"IMGUI_VERSION","FLT_MAX"}
-                                
 
 --funtion for parsing imgui headers
 local function parseImGuiHeader(header,names)

--- a/generator/generator.sh
+++ b/generator/generator.sh
@@ -15,5 +15,5 @@
 # arg[1] compiler name gcc, clang, or cl
 # arg[2] options as words in one string: internal for imgui_internal generation, freetype for freetype generation
 # examples: "" "internal" "internal freetype"
-# arg[3..n] name of implementations to generate
+# arg[3..n] name of implementations to generate and/or CLFLAGS (e.g. -DIMGUI_USER_CONFIG or -DIMGUI_USE_WCHAR32)
 luajit ./generator.lua gcc "internal" glfw opengl3 opengl2 sdl


### PR DESCRIPTION
This should solve the problems of #164 as well as a host of other possibilities.

Basically this adds the ability to add CFLAGS to the command line of `generator.lua` as long as they start with a dash. (Note this only works with `gcc` and `clang` since `cl` doesn't allow you to get `#defines`) We could add the slash for completeness, but the only place this is useful is inside the `get_defines()` function which clearly states that `cl` is incapable of supporting the call.

