### PR TITLE
generator: generate `-Wstrict-prototypes`-compatible code

### DIFF
--- a/generator/cimgui_template.h
+++ b/generator/cimgui_template.h
@@ -51,12 +51,12 @@ CIMGUI_API void igLogText(CONST char *fmt, ...);
 //no appendfV
 CIMGUI_API void ImGuiTextBuffer_appendf(struct ImGuiTextBuffer *buffer, const char *fmt, ...);
 //for getting FLT_MAX in bindings
-CIMGUI_API float igGET_FLT_MAX();
+CIMGUI_API float igGET_FLT_MAX(void);
 //for getting FLT_MIN in bindings
-CIMGUI_API float igGET_FLT_MIN();
+CIMGUI_API float igGET_FLT_MIN(void);
 
 
-CIMGUI_API ImVector_ImWchar* ImVector_ImWchar_create();
+CIMGUI_API ImVector_ImWchar* ImVector_ImWchar_create(void);
 CIMGUI_API void ImVector_ImWchar_destroy(ImVector_ImWchar* self);
 CIMGUI_API void ImVector_ImWchar_Init(ImVector_ImWchar* p);
 CIMGUI_API void ImVector_ImWchar_UnInit(ImVector_ImWchar* p);

--- a/generator/generator.lua
+++ b/generator/generator.lua
@@ -121,7 +121,8 @@ local function func_header_impl_generate(FP)
 			else
                 
                 if def.stname == "" then --ImGui namespace or top level
-                    table.insert(outtab,"CIMGUI_API".." "..def.ret.." "..def.ov_cimguiname..def.args..";"..addcoment.."\n")
+                    local empty = def.args:match("^%(%)") --no args
+                    table.insert(outtab,"CIMGUI_API".." "..def.ret.." "..def.ov_cimguiname..(empty and "(void)" or def.args)..";"..addcoment.."\n")
                 else
 					cpp2ffi.prtable(def)
                     error("class function in implementations")


### PR DESCRIPTION
Most places were already generating `(void)` instead of `()`, but a few places weren't.