### PR TITLE
Clearly fail when parse fails; exclude obsolete fns for cl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "imgui"]
 	path = imgui
 	url = https://github.com/ocornut/imgui.git
-	branch = master
+	branch = docking

--- a/generator/generator.lua
+++ b/generator/generator.lua
@@ -143,7 +143,7 @@ local func_implementation = cpp2ffi.func_implementation
 -------------------functions for getting and setting defines
 local function get_defines(t)
     local compiler_cmd = COMPILER == "cl"
-                         and COMPILER..[[ /TP /nologo /c /Fo"NUL" /I "]]..IMGUI_PATH..[[" print_defines.cpp]]..CFLAGS
+                         and COMPILER..[[ /TP /nologo /c /Fo"NUL" /DIMGUI_DISABLE_OBSOLETE_FUNCTIONS /I "]]..IMGUI_PATH..[[" print_defines.cpp]]..CFLAGS
                          or COMPILER..[[ -E -dM -DIMGUI_DISABLE_OBSOLETE_FUNCTIONS -DIMGUI_API="" -DIMGUI_IMPL_API="" ]]..IMGUI_PATH..[[/imgui.h]]..CFLAGS
     print(compiler_cmd)
     local pipe,err = io.popen(compiler_cmd,"r")

--- a/generator/generator.lua
+++ b/generator/generator.lua
@@ -148,17 +148,22 @@ local function get_defines(t)
     print(compiler_cmd)
     local pipe,err = io.popen(compiler_cmd,"r")
     local defines = {}
+    local output = { err }
     while true do
         local line = pipe:read"*l"
         if not line then break end
         local key,value = line:match([[^#define%s+(%S+)%s*(.*)]])
         if not key then --or not value then 
+            table.insert(output, line)
             --print(line)
         else
             defines[key]=value or ""
         end
     end
     pipe:close()
+    -- Might fail if imconfig.h includes headers to other parts of your
+    -- project. Try defining IMGUI_DISABLE_INCLUDE_IMCONFIG_H.
+    assert(next(defines), table.concat(output, "\n"))
     --require"anima.utils"
     --prtable(defines)
     --FLT_MAX
@@ -312,6 +317,7 @@ end
 --get imgui.h version and IMGUI_HAS_DOCK--------------------------
 --defines for the cl compiler must be present in the print_defines.cpp file
 gdefines = get_defines{"IMGUI_VERSION","FLT_MAX","FLT_MIN","IMGUI_HAS_DOCK","IMGUI_HAS_IMSTR"}
+assert(gdefines.IMGUI_VERSION, "Failed to read IMGUI_VERSION from imgui.h.")
 
 if gdefines.IMGUI_HAS_DOCK then gdefines.IMGUI_HAS_DOCK = true end
 if gdefines.IMGUI_HAS_IMSTR then gdefines.IMGUI_HAS_IMSTR = true end


### PR DESCRIPTION
Was trying to use cimgui for the imgui in bgfx (1.89 WIP and not docking branch) and ran into some headaches.

These two should help with that and make cl and gcc behave more similarly.