### PR TITLE
Parse comments for enums and functions

### DIFF
--- a/generator/generator.lua
+++ b/generator/generator.lua
@@ -381,12 +381,26 @@ parser1:do_parse()
 save_data("./output/overloads.txt",parser1.overloadstxt)
 cimgui_generation(parser1)
 
+local enum_comments = {}
+for line in io.lines(IMGUI_PATH .."/imgui.h") do
+    local name, comment = line:match("^%s+(%u%l%S+).-,.*//%s+(.*)$")
+    if name then
+        enum_comments[name] = comment
+    end
+end
+
 ----------save struct and enums lua table in structs_and_enums.lua for using in bindings
 
 local structs_and_enums_table = parser1.structs_and_enums_table
 structs_and_enums_table.templated_structs = parser1.templated_structs
 structs_and_enums_table.typenames = parser1.typenames
 structs_and_enums_table.templates_done = parser1.templates_done
+
+for name, vals in pairs(structs_and_enums_table.enums) do
+    for k, v in pairs(vals) do
+        v.comment = enum_comments[v.name]
+    end
+end
 
 save_data("./output/structs_and_enums.lua",serializeTableF(structs_and_enums_table))
 save_data("./output/typedefs_dict.lua",serializeTableF(parser1.typedefs_dict))


### PR DESCRIPTION
Resolves #212.

Parse comments for enums and functions. Works pretty well, but won't necessarily get everything. Getting the wrong comment seems like a very bad time. Seems more useful to have some comment support than none.

Structs would be pretty complex to handle since each line needs to know what struct it's part of so you'd need to push the struct on a stack. Not worthwhilte to me.

Could ensure more accuracy with enums if they also supported location like definitions.

Sample output (the `comment` field is new):

```lua
defs["igPushStyleColor"] = {}
defs["igPushStyleColor"][1] = {}
defs["igPushStyleColor"][1]["args"] = "(ImGuiCol idx,ImU32 col)"
defs["igPushStyleColor"][1]["argsT"] = {}
defs["igPushStyleColor"][1]["argsT"][1] = {}
defs["igPushStyleColor"][1]["argsT"][1]["name"] = "idx"
defs["igPushStyleColor"][1]["argsT"][1]["type"] = "ImGuiCol"
defs["igPushStyleColor"][1]["argsT"][2] = {}
defs["igPushStyleColor"][1]["argsT"][2]["name"] = "col"
defs["igPushStyleColor"][1]["argsT"][2]["type"] = "ImU32"
defs["igPushStyleColor"][1]["argsoriginal"] = "(ImGuiCol idx,ImU32 col)"
defs["igPushStyleColor"][1]["call_args"] = "(idx,col)"
defs["igPushStyleColor"][1]["cimguiname"] = "igPushStyleColor"
defs["igPushStyleColor"][1]["comment"] = "modify a style color. always use this if you modify the style after NewFrame()."
defs["igPushStyleColor"][1]["defaults"] = {}
defs["igPushStyleColor"][1]["funcname"] = "PushStyleColor"
defs["igPushStyleColor"][1]["location"] = "imgui:394"
defs["igPushStyleColor"][1]["namespace"] = "ImGui"
defs["igPushStyleColor"][1]["ov_cimguiname"] = "igPushStyleColor_U32"
defs["igPushStyleColor"][1]["ret"] = "void"
defs["igPushStyleColor"][1]["signature"] = "(ImGuiCol,ImU32)"
defs["igPushStyleColor"][1]["stname"] = ""
defs["igPushStyleColor"][2] = {}
defs["igPushStyleColor"][2]["args"] = "(ImGuiCol idx,const ImVec4 col)"
defs["igPushStyleColor"][2]["argsT"] = {}
defs["igPushStyleColor"][2]["argsT"][1] = {}
defs["igPushStyleColor"][2]["argsT"][1]["name"] = "idx"
defs["igPushStyleColor"][2]["argsT"][1]["type"] = "ImGuiCol"
defs["igPushStyleColor"][2]["argsT"][2] = {}
defs["igPushStyleColor"][2]["argsT"][2]["name"] = "col"
defs["igPushStyleColor"][2]["argsT"][2]["type"] = "const ImVec4"
defs["igPushStyleColor"][2]["argsoriginal"] = "(ImGuiCol idx,const ImVec4& col)"
defs["igPushStyleColor"][2]["call_args"] = "(idx,col)"
defs["igPushStyleColor"][2]["cimguiname"] = "igPushStyleColor"
defs["igPushStyleColor"][2]["defaults"] = {}
defs["igPushStyleColor"][2]["funcname"] = "PushStyleColor"
defs["igPushStyleColor"][2]["location"] = "imgui:395"
defs["igPushStyleColor"][2]["namespace"] = "ImGui"
defs["igPushStyleColor"][2]["ov_cimguiname"] = "igPushStyleColor_Vec4"
defs["igPushStyleColor"][2]["ret"] = "void"
defs["igPushStyleColor"][2]["signature"] = "(ImGuiCol,const ImVec4)"
defs["igPushStyleColor"][2]["stname"] = ""
defs["igPushStyleColor"]["(ImGuiCol,ImU32)"] = defs["igPushStyleColor"][1]
defs["igPushStyleColor"]["(ImGuiCol,const ImVec4)"] = defs["igPushStyleColor"][2]
```

```lua
defs["enums"]["ImDrawFlags_"] = {}
defs["enums"]["ImDrawFlags_"][1] = {}
defs["enums"]["ImDrawFlags_"][1]["calc_value"] = 0
defs["enums"]["ImDrawFlags_"][1]["name"] = "ImDrawFlags_None"
defs["enums"]["ImDrawFlags_"][1]["value"] = "0"
defs["enums"]["ImDrawFlags_"][2] = {}
defs["enums"]["ImDrawFlags_"][2]["calc_value"] = 1
defs["enums"]["ImDrawFlags_"][2]["comment"] = "PathStroke(), AddPolyline(): specify that shape should be closed (Important: this is always == 1 for legacy reason)"
defs["enums"]["ImDrawFlags_"][2]["name"] = "ImDrawFlags_Closed"
defs["enums"]["ImDrawFlags_"][2]["value"] = "1 << 0"
defs["enums"]["ImDrawFlags_"][3] = {}
defs["enums"]["ImDrawFlags_"][3]["calc_value"] = 16
defs["enums"]["ImDrawFlags_"][3]["comment"] = "AddRect(), AddRectFilled(), PathRect(): enable rounding top-left corner only (when rounding > 0.0f, we default to all corners). Was 0x01."
defs["enums"]["ImDrawFlags_"][3]["name"] = "ImDrawFlags_RoundCornersTopLeft"
defs["enums"]["ImDrawFlags_"][3]["value"] = "1 << 4"
defs["enums"]["ImDrawFlags_"][4] = {}
defs["enums"]["ImDrawFlags_"][4]["calc_value"] = 32
defs["enums"]["ImDrawFlags_"][4]["comment"] = "AddRect(), AddRectFilled(), PathRect(): enable rounding top-right corner only (when rounding > 0.0f, we default to all corners). Was 0x02."
defs["enums"]["ImDrawFlags_"][4]["name"] = "ImDrawFlags_RoundCornersTopRight"
defs["enums"]["ImDrawFlags_"][4]["value"] = "1 << 5"
```