### PR TITLE
Fix windows CI builds (#226)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
         elif [ "$GITHUB_OS" == "windows-latest" ];
         then
           vcpkg install luajit
+          echo "/C/vcpkg/packages/luajit_x86-windows/tools" >> $GITHUB_PATH
+          echo "/C/vcpkg/packages/luajit_x86-windows/bin"   >> $GITHUB_PATH
         fi
 
     - name: Download Submodules
@@ -47,7 +49,6 @@ jobs:
     - name: Generate Bindings
       shell: bash
       run: |
-        export PATH=$PATH:/C/vcpkg/packages/luajit_x86-windows/tools/:/C/vcpkg/packages/luajit_x86-windows/bin/
         cd ./generator
         bash ./generator.sh
 

--- a/generator/generator.sh
+++ b/generator/generator.sh
@@ -16,4 +16,10 @@
 # arg[2] options as words in one string: internal for imgui_internal generation, freetype for freetype generation, comments for comments generation
 # examples: "" "internal" "internal freetype" "comments internal"
 # arg[3..n] name of implementations to generate and/or CLFLAGS (e.g. -DIMGUI_USER_CONFIG or -DIMGUI_USE_WCHAR32)
-luajit ./generator.lua gcc "internal" glfw opengl3 opengl2 sdl
+
+if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]];
+then
+  suffix='.exe'
+fi
+
+luajit$suffix ./generator.lua gcc "internal" glfw opengl3 opengl2 sdl


### PR DESCRIPTION
For some reason `luajit` command without `.exe` no longer works. No idea why.. Lets just use `.exe` on windows and call it a day. Also switched `PATH` updates to new proper way. Does not really impact anything.. Just a general janitorial change.