### PR TITLE
use "installed" directory for vcpkg instead of packages and explicitly install x64 target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,8 @@ jobs:
         elif [ "$GITHUB_OS" == "windows-latest" ];
         then
           vcpkg install luajit
-          echo "/C/vcpkg/packages/luajit_x86-windows/tools" >> $GITHUB_PATH
-          echo "/C/vcpkg/packages/luajit_x86-windows/bin"   >> $GITHUB_PATH
+          echo "/C/vcpkg/installed/x86-windows/tools/luajit" >> $GITHUB_PATH
+          echo "/C/vcpkg/installed/x86-windows/bin"   >> $GITHUB_PATH
         fi
 
     - name: Download Submodules

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,9 @@ jobs:
           sudo apt-get install -y luajit
         elif [ "$GITHUB_OS" == "windows-latest" ];
         then
-          vcpkg install luajit
-          echo "/C/vcpkg/installed/x86-windows/tools/luajit" >> $GITHUB_PATH
-          echo "/C/vcpkg/installed/x86-windows/bin"   >> $GITHUB_PATH
+          vcpkg install luajit:x64-windows
+          echo "/C/vcpkg/installed/x64-windows/tools/luajit" >> $GITHUB_PATH
+          echo "/C/vcpkg/installed/x64-windows/bin"   >> $GITHUB_PATH
         fi
 
     - name: Download Submodules


### PR DESCRIPTION
closes: #242

It seems like Github Action's vcpkg no longer keeps the installed packages in the "packages". (Perhaps it is using the `--clean-after-build` flag by default now?).

This PR adds the "installed" directory to PATH instead of "packages" which i think is more correct anyway.

here is a CI run for the first commit showing that it's to do with using the packages dir: [CI](https://github.com/xEgoist/cimgui/actions/runs/5342628254/jobs/9684678284)

Also, as stated in the issue, since vcpkg is transitioning to host default,  I added explicit triplet in a separate commit. (i can take that out if it's not desired for now)

 