### PR TITLE
Makefile: clean target for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,18 @@ $(OUTPUTNAME):$(OBJS)
 	$(CXX) -o $(OUTPUTNAME) $(OBJS) $(CXXFLAGS) $(LINKFLAGS)
 
 clean:
+ifeq ($(OS),Windows_NT)
+	del /q $(subst /,\,$(OBJS))
+else
 	rm -f $(OBJS)
+endif
 
 fclean: clean
+ifeq ($(OS),Windows_NT)
+	del /q $(subst /,\,$(OUTPUTNAME))
+else
 	rm -f $(OUTPUTNAME)
+endif
 
 re: fclean all
 


### PR DESCRIPTION
Added check in clean and fclean targets to use "del" instead of "rm" on Windows, because Windows' command prompt does not have "rm"
The subst replaces "/" by "\" only because del expects paths to use "\" as separators instead of "/"