### PR TITLE
Allow use of zig cc in generator.lua

### DIFF
--- a/generator/generator.lua
+++ b/generator/generator.lua
@@ -33,7 +33,7 @@ if FREETYPE_GENERATION then
 	CFLAGS = CFLAGS .. " -DIMGUI_ENABLE_FREETYPE "
 end
 
-if COMPILER == "gcc" or COMPILER == "clang" then
+if COMPILER == "gcc" or COMPILER == "clang" or COMPILER == "zig cc" then
     CPRE = COMPILER..[[ -E -DIMGUI_DISABLE_OBSOLETE_FUNCTIONS -DIMGUI_API="" -DIMGUI_IMPL_API="" ]] .. CFLAGS
     CTEST = COMPILER.." --version"
 elseif COMPILER == "cl" then


### PR DESCRIPTION
Allows use of the [Zig](https://github.com/ziglang/zig) compiler's built in C compiler interface, `zig cc`, to be used in `generator.lua`. Since it has the same CLI interface as Clang, no extra work needs to be done. This helps to avoid a dependency on an extra compiler if generation is part of the build process for a Zig project.