### PR TITLE
feat: add sdl3 vulkan backend

### DIFF
--- a/backend_test/example_sdl3_vulkan/CMakeLists.txt
+++ b/backend_test/example_sdl3_vulkan/CMakeLists.txt
@@ -1,0 +1,100 @@
+cmake_minimum_required(VERSION 2.8)
+Project(cimgui_sdl3_vk)
+if(WIN32) # to make mingw work as all the others
+set(CMAKE_SHARED_LIBRARY_PREFIX "")
+endif(WIN32)
+# general settings
+
+
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../imgui/backends)
+	set(BACKENDS_FOLDER "../../imgui/backends/")
+else()
+	set(BACKENDS_FOLDER "../../imgui/examples/")
+endif()
+
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../imgui/imgui_tables.cpp)
+	set(TABLES_SOURCE "../../imgui/imgui_tables.cpp")
+else()
+	set(TABLES_SOURCE "")
+endif()
+
+include_directories(../../imgui ../../imgui/backends)
+
+
+include_directories(../../)
+set(IMGUI_SOURCES ../../cimgui.cpp
+../../cimgui_impl.cpp
+../../imgui/imgui.cpp
+../../imgui/imgui_draw.cpp
+../../imgui/imgui_demo.cpp
+../../imgui/imgui_widgets.cpp
+${TABLES_SOURCE}
+)
+
+set(IMGUI_SOURCES_sdl)
+set(IMGUI_LIBRARIES )
+
+
+#optional adding freetype
+option(IMGUI_FREETYPE "add Freetype2" OFF)
+
+if(IMGUI_FREETYPE)
+	FIND_PACKAGE(freetype REQUIRED PATHS ${FREETYPE_PATH})
+	list(APPEND IMGUI_LIBRARIES freetype)
+	list(APPEND IMGUI_SOURCES ../../imgui/misc/freetype/imgui_freetype.cpp)
+	add_definitions("-DCIMGUI_FREETYPE=1")
+endif(IMGUI_FREETYPE)
+
+# vulkan
+find_package(Vulkan REQUIRED FATAL_ERROR)
+list(APPEND IMGUI_LIBRARIES Vulkan::Vulkan)
+list(APPEND IMGUI_SOURCES ${BACKENDS_FOLDER}imgui_impl_vulkan.cpp)
+include_directories(${Vulkan_INCLUDE_DIRS})
+
+#sdl3
+list(APPEND IMGUI_SOURCES ${BACKENDS_FOLDER}imgui_impl_sdl3.cpp)
+include(FetchContent)
+Set(FETCHCONTENT_QUIET FALSE)
+
+FetchContent_Declare(
+        SDL3
+        GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
+        GIT_TAG release-3.2.8
+        #GIT_SHALLOW TRUE
+        GIT_PROGRESS TRUE
+)
+FetchContent_GetProperties(SDL3)
+if (NOT sdl3_POPULATED)
+	set(FETCHCONTENT_QUIET NO)
+    FetchContent_Populate(SDL3)
+	set(SDL_TEST OFF CACHE BOOL "" FORCE)
+	set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+	add_subdirectory(${sdl3_SOURCE_DIR} ${sdl3_BINARY_DIR})
+endif()
+include_directories(${SDL3_SOURCE_DIR}/include)
+
+
+#if dynamic SDL3 then install
+# install(TARGETS SDL3 RUNTIME DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+					# LIBRARY DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+# )
+
+add_library(cimgui_sdl STATIC ${IMGUI_SOURCES})
+target_compile_definitions(cimgui_sdl PUBLIC "-DIMGUI_USER_CONFIG=\"../cimconfig.h\"")
+target_compile_definitions(cimgui_sdl PUBLIC "-DIMGUI_DISABLE_OBSOLETE_FUNCTIONS=1")
+target_compile_definitions(cimgui_sdl PUBLIC -DCIMGUI_USE_VULKAN -DCIMGUI_USE_SDL3)
+if (WIN32)
+    target_compile_definitions(cimgui_sdl PUBLIC "-DIMGUI_IMPL_API=extern \"C\" __declspec\(dllexport\)")
+else(WIN32)
+    target_compile_definitions(cimgui_sdl PUBLIC "-DIMGUI_IMPL_API=extern \"C\" ")
+endif(WIN32)
+#target_link_libraries(cimgui_sdl ${IMGUI_LIBRARIES} SDL3-static)
+
+#using library
+add_executable(test_sdl main.c)
+target_compile_definitions(test_sdl PUBLIC -DCIMGUI_USE_VULKAN -DCIMGUI_USE_SDL3)
+if (MINGW)
+target_link_options(test_sdl PRIVATE "-mconsole")
+endif()
+target_link_libraries(test_sdl SDL3-static cimgui_sdl ${IMGUI_LIBRARIES})
+

--- a/backend_test/example_sdl3_vulkan/README.md
+++ b/backend_test/example_sdl3_vulkan/README.md
@@ -1,0 +1,2 @@
+
+To build use `cmake path_to_example_sdl3_vulkan` and then `make install`

--- a/backend_test/example_sdl3_vulkan/main.c
+++ b/backend_test/example_sdl3_vulkan/main.c
@@ -1,0 +1,625 @@
+#include <stdio.h>          // printf, fprintf
+#include <stdlib.h>         // abort
+#include <assert.h>
+#define SDL_MAIN_HANDLED
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_vulkan.h>
+#include <vulkan/vulkan.h>
+// Volk headers
+#ifdef IMGUI_IMPL_VULKAN_USE_VOLK
+#define VOLK_IMPLEMENTATION
+#include <volk.h>
+#endif
+
+//this must be equal to that in imgui_impl_vulkan.h
+#define IMGUI_IMPL_VULKAN_MINIMUM_IMAGE_SAMPLER_POOL_SIZE   (1)     // Minimum per atlas
+
+#define CIMGUI_DEFINE_ENUMS_AND_STRUCTS
+#include <cimgui.h>
+#include <cimgui_impl.h>
+
+#ifdef IMGUI_HAS_IMSTR
+#define igBegin igBegin_Str
+#define igSliderFloat igSliderFloat_Str
+#define igCheckbox igCheckbox_Str
+#define igColorEdit3 igColorEdit3_Str
+#define igButton igButton_Str
+#endif
+
+#define igGetIO igGetIO_Nil
+
+#define IM_UNUSED(_VAR)  ((void)(_VAR))
+#define IM_ASSERT(_EXPR) assert(_EXPR)
+#define IM_ARRAYSIZE(_ARR) ((int)(sizeof(_ARR) / sizeof(*(_ARR))))
+
+//#define APP_USE_UNLIMITED_FRAME_RATE
+#ifdef _DEBUG
+#define APP_USE_VULKAN_DEBUG_REPORT
+#endif
+#define APP_USE_VULKAN_DEBUG_REPORT
+// Data
+static VkAllocationCallbacks*   g_Allocator = NULL;
+static VkInstance               g_Instance = VK_NULL_HANDLE;
+static VkPhysicalDevice         g_PhysicalDevice = VK_NULL_HANDLE;
+static VkDevice                 g_Device = VK_NULL_HANDLE;
+static uint32_t                 g_QueueFamily = (uint32_t)-1;
+static VkQueue                  g_Queue = VK_NULL_HANDLE;
+static VkDebugReportCallbackEXT g_DebugReport = VK_NULL_HANDLE;
+static VkPipelineCache          g_PipelineCache = VK_NULL_HANDLE;
+static VkDescriptorPool         g_DescriptorPool = VK_NULL_HANDLE;
+
+static ImGui_ImplVulkanH_Window g_MainWindowData;
+static uint32_t                 g_MinImageCount = 2;
+static bool                     g_SwapChainRebuild = false;
+
+static void check_vk_result(VkResult err)
+{
+    if (err == VK_SUCCESS)
+        return;
+    fprintf(stderr, "[vulkan] Error: VkResult = %d\n", err);
+    if (err < 0)
+        abort();
+}
+
+static void check_vk_result_line(VkResult err,int line)
+{
+    if (err == VK_SUCCESS)
+        return;
+    fprintf(stderr, "[vulkan] Error: VkResult = %d in line: (%d)\n", err, line);
+    if (err < 0)
+        abort();
+}
+
+#ifdef APP_USE_VULKAN_DEBUG_REPORT
+static VKAPI_ATTR VkBool32 VKAPI_CALL debug_report(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT objectType, uint64_t object, size_t location, int32_t messageCode, const char* pLayerPrefix, const char* pMessage, void* pUserData)
+{
+    (void)flags; (void)object; (void)location; (void)messageCode; (void)pUserData; (void)pLayerPrefix; // Unused arguments
+    fprintf(stderr, "[vulkan] Debug report from ObjectType: %i\nMessage: %s\n\n", objectType, pMessage);
+    return VK_FALSE;
+}
+#endif // APP_USE_VULKAN_DEBUG_REPORT
+//*
+static bool IsExtensionAvailable(VkExtensionProperties* properties, uint32_t properties_count, const char* extension)
+{
+    for(uint32_t i = 0 ; i < properties_count; i++){
+        if (strcmp(properties[i].extensionName, extension) == 0)
+            return true;
+    }
+    return false;
+}
+
+static void SetupVulkan(const char** extensions, uint32_t extensions_count)
+{
+    VkResult err;
+#ifdef IMGUI_IMPL_VULKAN_USE_VOLK
+    volkInitialize();
+#endif
+
+    // Create Vulkan Instance
+    {
+        VkInstanceCreateInfo create_info = {};
+        create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+
+        // Enumerate available extensions
+        uint32_t properties_count;
+        vkEnumerateInstanceExtensionProperties(NULL, &properties_count, NULL);
+        VkExtensionProperties* properties = (VkExtensionProperties*)malloc(properties_count * sizeof(VkExtensionProperties));
+        err = vkEnumerateInstanceExtensionProperties(NULL, &properties_count, properties);
+        check_vk_result_line(err, __LINE__);
+
+        // Enable required extensions
+        if (IsExtensionAvailable(properties, properties_count, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)){
+            //instance_extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+            extensions_count++;
+            extensions = realloc(extensions, extensions_count * sizeof(char*));
+            assert(extensions);
+            extensions[extensions_count-1] = VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME;
+        }
+#ifdef VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+        if (IsExtensionAvailable(properties, properties_count, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME))
+        {
+            //instance_extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+            extensions_count++;
+            extensions = realloc(extensions, extensions_count * sizeof(char*));
+            assert(extensions);
+            extensions[extensions_count-1] = VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME;
+            create_info.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+        }
+#endif
+        free(properties);
+        // Enabling validation layers
+#ifdef APP_USE_VULKAN_DEBUG_REPORT
+        const char* layers[] = { "VK_LAYER_KHRONOS_validation" };
+        create_info.enabledLayerCount = 1;
+        create_info.ppEnabledLayerNames = layers;
+        //instance_extensions.push_back("VK_EXT_debug_report");
+        extensions_count++;
+        extensions = realloc(extensions, extensions_count * sizeof(char*));
+        assert(extensions);
+        extensions[extensions_count-1] = "VK_EXT_debug_report";
+#endif
+
+        // Create Vulkan Instance
+        create_info.enabledExtensionCount = extensions_count;//(uint32_t)instance_extensions.Size;
+        create_info.ppEnabledExtensionNames = extensions;//instance_extensions.Data;
+        err = vkCreateInstance(&create_info, g_Allocator, &g_Instance);
+        check_vk_result_line(err, __LINE__);
+#ifdef IMGUI_IMPL_VULKAN_USE_VOLK
+        volkLoadInstance(g_Instance);
+#endif
+
+        // Setup the debug report callback
+#ifdef APP_USE_VULKAN_DEBUG_REPORT
+        PFN_vkCreateDebugReportCallbackEXT f_vkCreateDebugReportCallbackEXT = (PFN_vkCreateDebugReportCallbackEXT)vkGetInstanceProcAddr(g_Instance, "vkCreateDebugReportCallbackEXT");
+        IM_ASSERT(f_vkCreateDebugReportCallbackEXT != NULL);
+        VkDebugReportCallbackCreateInfoEXT debug_report_ci = {};
+        debug_report_ci.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT;
+        debug_report_ci.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT;
+        debug_report_ci.pfnCallback = debug_report;
+        debug_report_ci.pUserData = NULL;
+        err = f_vkCreateDebugReportCallbackEXT(g_Instance, &debug_report_ci, g_Allocator, &g_DebugReport);
+        check_vk_result_line(err, __LINE__);
+#endif
+    }
+    // Select Physical Device (GPU)
+    g_PhysicalDevice = ImGui_ImplVulkanH_SelectPhysicalDevice(g_Instance);
+    IM_ASSERT(g_PhysicalDevice != VK_NULL_HANDLE);
+    // Select graphics queue family
+    g_QueueFamily = ImGui_ImplVulkanH_SelectQueueFamilyIndex(g_PhysicalDevice);
+    IM_ASSERT(g_QueueFamily != (uint32_t)-1);
+
+    // Create Logical Device (with 1 queue)
+    {
+        //ImVector<const char*> device_extensions;
+        //device_extensions.push_back("VK_KHR_swapchain");
+        uint32_t device_extensions_count = 1;
+        const char** device_extensions = (const char**)malloc(device_extensions_count * sizeof(char*));
+        device_extensions[0] = "VK_KHR_swapchain";
+
+        // Enumerate physical device extension
+        uint32_t properties_count;
+        //ImVector<VkExtensionProperties> properties;
+        vkEnumerateDeviceExtensionProperties(g_PhysicalDevice, NULL, &properties_count, NULL);
+        //properties.resize(properties_count);
+        VkExtensionProperties* properties = (VkExtensionProperties*)malloc(properties_count * sizeof(VkExtensionProperties));
+        vkEnumerateDeviceExtensionProperties(g_PhysicalDevice, NULL, &properties_count, properties);
+#ifdef VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME
+        if (IsExtensionAvailable(properties, properties_count, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)){
+            //device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+            device_extensions_count++;
+            device_extensions = realloc(device_extensions, device_extensions_count * sizeof(const char*));
+            assert(device_extensions);
+            device_extensions[device_extensions_count-1] = VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME;
+        }
+#endif
+
+        const float queue_priority[] = { 1.0f };
+        VkDeviceQueueCreateInfo queue_info[1] = {};
+        queue_info[0].sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+        queue_info[0].queueFamilyIndex = g_QueueFamily;
+        queue_info[0].queueCount = 1;
+        queue_info[0].pQueuePriorities = queue_priority;
+        VkDeviceCreateInfo create_info = {};
+        create_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+        create_info.queueCreateInfoCount = sizeof(queue_info) / sizeof(queue_info[0]);
+        create_info.pQueueCreateInfos = queue_info;
+        create_info.enabledExtensionCount = device_extensions_count; //(uint32_t)device_extensions.Size;
+        create_info.ppEnabledExtensionNames = device_extensions;//device_extensions.Data;
+        err = vkCreateDevice(g_PhysicalDevice, &create_info, g_Allocator, &g_Device);
+        check_vk_result_line(err, __LINE__);
+        vkGetDeviceQueue(g_Device, g_QueueFamily, 0, &g_Queue);
+    }
+    // Create Descriptor Pool
+    // If you wish to load e.g. additional textures you may need to alter pools sizes and maxSets.
+    {
+        VkDescriptorPoolSize pool_sizes[] =
+        {
+            { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, IMGUI_IMPL_VULKAN_MINIMUM_IMAGE_SAMPLER_POOL_SIZE },
+        };
+        VkDescriptorPoolCreateInfo pool_info = {};
+        pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+        pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+        pool_info.maxSets = 0;
+        //for (VkDescriptorPoolSize& pool_size : pool_sizes)
+        //    pool_info.maxSets += pool_size.descriptorCount;
+        for(int i = 0; i < IM_ARRAYSIZE(pool_sizes); i++){
+            VkDescriptorPoolSize pool_size = pool_sizes[i];
+            pool_info.maxSets += pool_size.descriptorCount;
+        }
+        pool_info.poolSizeCount = (uint32_t)IM_ARRAYSIZE(pool_sizes);
+        pool_info.pPoolSizes = pool_sizes;
+        err = vkCreateDescriptorPool(g_Device, &pool_info, g_Allocator, &g_DescriptorPool);
+        check_vk_result_line(err, __LINE__);
+    }
+}
+//*/
+// All the ImGui_ImplVulkanH_XXX structures/functions are optional helpers used by the demo.
+// Your real engine/app may not use them.
+static void SetupVulkanWindow(ImGui_ImplVulkanH_Window* wd, VkSurfaceKHR surface, int width, int height)
+{
+    wd->Surface = surface;
+
+    // Check for WSI support
+    VkBool32 res;
+    vkGetPhysicalDeviceSurfaceSupportKHR(g_PhysicalDevice, g_QueueFamily, wd->Surface, &res);
+    if (res != VK_TRUE)
+    {
+        fprintf(stderr, "Error no WSI support on physical device 0\n");
+        exit(-1);
+    }
+
+    // Select Surface Format
+    const VkFormat requestSurfaceImageFormat[] = { VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_B8G8R8_UNORM, VK_FORMAT_R8G8B8_UNORM };
+    const VkColorSpaceKHR requestSurfaceColorSpace = VK_COLORSPACE_SRGB_NONLINEAR_KHR;
+    wd->SurfaceFormat = ImGui_ImplVulkanH_SelectSurfaceFormat(g_PhysicalDevice, wd->Surface, requestSurfaceImageFormat, (size_t)IM_ARRAYSIZE(requestSurfaceImageFormat), requestSurfaceColorSpace);
+
+    // Select Present Mode
+#ifdef APP_USE_UNLIMITED_FRAME_RATE
+    VkPresentModeKHR present_modes[] = { VK_PRESENT_MODE_MAILBOX_KHR, VK_PRESENT_MODE_IMMEDIATE_KHR, VK_PRESENT_MODE_FIFO_KHR };
+#else
+    VkPresentModeKHR present_modes[] = { VK_PRESENT_MODE_FIFO_KHR };
+#endif
+    wd->PresentMode = ImGui_ImplVulkanH_SelectPresentMode(g_PhysicalDevice, wd->Surface, &present_modes[0], IM_ARRAYSIZE(present_modes));
+    //printf("[vulkan] Selected PresentMode = %d\n", wd->PresentMode);
+
+    // Create SwapChain, RenderPass, Framebuffer, etc.
+    IM_ASSERT(g_MinImageCount >= 2);
+    ImGui_ImplVulkanH_CreateOrResizeWindow(g_Instance, g_PhysicalDevice, g_Device, wd, g_QueueFamily, g_Allocator, width, height, g_MinImageCount);
+}
+
+static void CleanupVulkan()
+{
+    vkDestroyDescriptorPool(g_Device, g_DescriptorPool, g_Allocator);
+
+#ifdef APP_USE_VULKAN_DEBUG_REPORT
+    // Remove the debug report callback
+    PFN_vkDestroyDebugReportCallbackEXT f_vkDestroyDebugReportCallbackEXT = (PFN_vkDestroyDebugReportCallbackEXT)vkGetInstanceProcAddr(g_Instance, "vkDestroyDebugReportCallbackEXT");
+    f_vkDestroyDebugReportCallbackEXT(g_Instance, g_DebugReport, g_Allocator);
+#endif // APP_USE_VULKAN_DEBUG_REPORT
+
+    vkDestroyDevice(g_Device, g_Allocator);
+    vkDestroyInstance(g_Instance, g_Allocator);
+}
+
+static void CleanupVulkanWindow()
+{
+    ImGui_ImplVulkanH_DestroyWindow(g_Instance, g_Device, &g_MainWindowData, g_Allocator);
+}
+
+static void FrameRender(ImGui_ImplVulkanH_Window* wd, ImDrawData* draw_data)
+{
+    VkSemaphore image_acquired_semaphore  = wd->FrameSemaphores.Data[wd->SemaphoreIndex].ImageAcquiredSemaphore;
+    VkSemaphore render_complete_semaphore = wd->FrameSemaphores.Data[wd->SemaphoreIndex].RenderCompleteSemaphore;
+    VkResult err = vkAcquireNextImageKHR(g_Device, wd->Swapchain, UINT64_MAX, image_acquired_semaphore, VK_NULL_HANDLE, &wd->FrameIndex);
+    if (err == VK_ERROR_OUT_OF_DATE_KHR || err == VK_SUBOPTIMAL_KHR)
+        g_SwapChainRebuild = true;
+    if (err == VK_ERROR_OUT_OF_DATE_KHR)
+        return;
+    if (err != VK_SUBOPTIMAL_KHR)
+        check_vk_result_line(err, __LINE__);
+
+    ImGui_ImplVulkanH_Frame* fd = &wd->Frames.Data[wd->FrameIndex];
+    {
+        err = vkWaitForFences(g_Device, 1, &fd->Fence, VK_TRUE, UINT64_MAX);    // wait indefinitely instead of periodically checking
+        check_vk_result_line(err, __LINE__);
+
+        err = vkResetFences(g_Device, 1, &fd->Fence);
+        check_vk_result_line(err, __LINE__);
+    }
+    {
+        err = vkResetCommandPool(g_Device, fd->CommandPool, 0);
+        check_vk_result_line(err, __LINE__);
+        VkCommandBufferBeginInfo info = {};
+        info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        info.flags |= VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        err = vkBeginCommandBuffer(fd->CommandBuffer, &info);
+        check_vk_result_line(err, __LINE__);
+    }
+    {
+        VkRenderPassBeginInfo info = {};
+        info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+        info.renderPass = wd->RenderPass;
+        info.framebuffer = fd->Framebuffer;
+        info.renderArea.extent.width = wd->Width;
+        info.renderArea.extent.height = wd->Height;
+        info.clearValueCount = 1;
+        info.pClearValues = &wd->ClearValue;
+        vkCmdBeginRenderPass(fd->CommandBuffer, &info, VK_SUBPASS_CONTENTS_INLINE);
+    }
+
+    // Record dear imgui primitives into command buffer
+    ImGui_ImplVulkan_RenderDrawData(draw_data, fd->CommandBuffer, VK_NULL_HANDLE);
+
+    // Submit command buffer
+    vkCmdEndRenderPass(fd->CommandBuffer);
+    {
+        VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        VkSubmitInfo info = {};
+        info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        info.waitSemaphoreCount = 1;
+        info.pWaitSemaphores = &image_acquired_semaphore;
+        info.pWaitDstStageMask = &wait_stage;
+        info.commandBufferCount = 1;
+        info.pCommandBuffers = &fd->CommandBuffer;
+        info.signalSemaphoreCount = 1;
+        info.pSignalSemaphores = &render_complete_semaphore;
+
+        err = vkEndCommandBuffer(fd->CommandBuffer);
+        check_vk_result_line(err, __LINE__);
+        err = vkQueueSubmit(g_Queue, 1, &info, fd->Fence);
+        check_vk_result_line(err, __LINE__);
+    }
+}
+
+static void FramePresent(ImGui_ImplVulkanH_Window* wd)
+{
+    if (g_SwapChainRebuild)
+        return;
+    VkSemaphore render_complete_semaphore = wd->FrameSemaphores.Data[wd->SemaphoreIndex].RenderCompleteSemaphore;
+    VkPresentInfoKHR info = {};
+    info.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+    info.waitSemaphoreCount = 1;
+    info.pWaitSemaphores = &render_complete_semaphore;
+    info.swapchainCount = 1;
+    info.pSwapchains = &wd->Swapchain;
+    info.pImageIndices = &wd->FrameIndex;
+    VkResult err = vkQueuePresentKHR(g_Queue, &info);
+    if (err == VK_ERROR_OUT_OF_DATE_KHR || err == VK_SUBOPTIMAL_KHR)
+        g_SwapChainRebuild = true;
+    if (err == VK_ERROR_OUT_OF_DATE_KHR)
+        return;
+    if (err != VK_SUBOPTIMAL_KHR)
+        check_vk_result_line(err, __LINE__);
+    wd->SemaphoreIndex = (wd->SemaphoreIndex + 1) % wd->SemaphoreCount; // Now we can use the next set of semaphores
+}
+
+// Main code
+int main(int argc, char* argv[])
+{
+    //g_MainWindowData.ClearEnable = true;
+	//ImGui_ImplVulkanH_Window_Construct(&g_MainWindowData);
+	g_MainWindowData = *ImGui_ImplVulkanH_Window_ImGui_ImplVulkanH_Window();
+    // Setup SDL
+    if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD))
+    {
+        printf("Error: SDL_Init(): %s\n", SDL_GetError());
+        return -1;
+    }
+
+    // From 2.0.18: Enable native IME.
+#ifdef SDL_HINT_IME_SHOW_UI
+    SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
+#endif
+
+    // Create window with Vulkan graphics context
+    SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY | SDL_WINDOW_HIDDEN);
+    SDL_Window* window = SDL_CreateWindow("Dear ImGui SDL3+Vulkan example", 1280, 720, window_flags);
+    if (window == NULL)
+    {
+        printf("Error: SDL_CreateWindow(): %s\n", SDL_GetError());
+        return -1;
+    }
+  // Setup Vulkan
+  uint32_t extensions_count = 0;
+  const char *const *extensions_nude = SDL_Vulkan_GetInstanceExtensions(&extensions_count);
+  if (extensions_nude == NULL) {
+    printf("Error: SDL_Vulkan_GetInstanceExtensions(): %s\n", SDL_GetError());
+    return -1;
+  }
+  const char** extensions = (const char**)malloc(extensions_count * sizeof(const char*));
+  if (extensions == NULL) {
+    printf("Error allocating space for extensions array\n");
+    return -1;
+  }
+  for (int i = 0; i < extensions_count; i++) {
+    extensions[i] = extensions_nude[i];
+  }
+  SetupVulkan(extensions, extensions_count);
+  //leak?? but free crashes
+  // free(extensions);
+    // Create Window Surface
+    VkSurfaceKHR surface;
+    VkResult err;
+    if (SDL_Vulkan_CreateSurface(window, g_Instance, g_Allocator, &surface) == 0)
+    {
+        printf("Failed to create Vulkan surface.\n");
+        return 1;
+    }
+
+    // Create Framebuffers
+    int w, h;
+    SDL_GetWindowSize(window, &w, &h);
+    ImGui_ImplVulkanH_Window* wd = &g_MainWindowData;
+    SetupVulkanWindow(wd, surface, w, h);
+    SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+    SDL_ShowWindow(window);
+
+    // Setup Dear ImGui context
+    //IMGUI_CHECKVERSION();
+    igCreateContext(NULL);
+    ImGuiIO* io = igGetIO(); (void)io;
+    io->ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
+    io->ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
+    io->ConfigFlags |= ImGuiConfigFlags_DockingEnable;         // Enable Docking
+    io->ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;       // Enable Multi-Viewport / Platform Windows
+    //io.ConfigFlags |= ImGuiConfigFlags_ViewportsNoTaskBarIcons;
+    //io.ConfigFlags |= ImGuiConfigFlags_ViewportsNoMerge;
+
+    // Setup Dear ImGui style
+    igStyleColorsDark(NULL);
+    //ImGui::StyleColorsLight();
+
+    // When viewports are enabled we tweak WindowRounding/WindowBg so platform windows can look identical to regular ones.
+    ImGuiStyle* style = igGetStyle();
+    if (io->ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
+    {
+        style->WindowRounding = 0.0f;
+        style->Colors[ImGuiCol_WindowBg].w = 1.0f;
+    }
+
+    // Setup Platform/Renderer backends
+    ImGui_ImplSDL3_InitForVulkan(window);
+    ImGui_ImplVulkan_InitInfo init_info = {};
+    init_info.Instance = g_Instance;
+    init_info.PhysicalDevice = g_PhysicalDevice;
+    init_info.Device = g_Device;
+    init_info.QueueFamily = g_QueueFamily;
+    init_info.Queue = g_Queue;
+    init_info.PipelineCache = g_PipelineCache;
+    init_info.DescriptorPool = g_DescriptorPool;
+    init_info.RenderPass = wd->RenderPass;
+    init_info.Subpass = 0;
+    init_info.MinImageCount = g_MinImageCount;
+    init_info.ImageCount = wd->ImageCount;
+    init_info.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
+    init_info.Allocator = g_Allocator;
+    init_info.CheckVkResultFn = check_vk_result;
+    ImGui_ImplVulkan_Init(&init_info);
+
+    // Load Fonts
+    // - If no fonts are loaded, dear imgui will use the default font. You can also load multiple fonts and use ImGui::PushFont()/PopFont() to select them.
+    // - AddFontFromFileTTF() will return the ImFont* so you can store it if you need to select the font among multiple.
+    // - If the file cannot be loaded, the function will return a nullptr. Please handle those errors in your application (e.g. use an assertion, or display an error and quit).
+    // - The fonts will be rasterized at a given size (w/ oversampling) and stored into a texture when calling ImFontAtlas::Build()/GetTexDataAsXXXX(), which ImGui_ImplXXXX_NewFrame below will call.
+    // - Use '#define IMGUI_ENABLE_FREETYPE' in your imconfig file to use Freetype for higher quality font rendering.
+    // - Read 'docs/FONTS.md' for more instructions and details.
+    // - Remember that in C/C++ if you want to include a backslash \ in a string literal you need to write a double backslash \\ !
+    //io.Fonts->AddFontDefault();
+    //io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\segoeui.ttf", 18.0f);
+    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/DroidSans.ttf", 16.0f);
+    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/Roboto-Medium.ttf", 16.0f);
+    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/Cousine-Regular.ttf", 15.0f);
+    //ImFont* font = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf", 18.0f, nullptr, io.Fonts->GetGlyphRangesJapanese());
+    //IM_ASSERT(font != nullptr);
+
+    // Our state
+    bool show_demo_window = true;
+    bool show_another_window = false;
+    ImVec4 clear_color;
+    clear_color.x = 0.45f;
+    clear_color.y = 0.55f;
+    clear_color.z = 0.60f;
+    clear_color.w = 1.00f;
+
+    // Main loop
+    bool done = false;
+    while (!done)
+    {
+        // Poll and handle events (inputs, window resize, etc.)
+        // You can read the io.WantCaptureMouse, io.WantCaptureKeyboard flags to tell if dear imgui wants to use your inputs.
+        // - When io.WantCaptureMouse is true, do not dispatch mouse input data to your main application, or clear/overwrite your copy of the mouse data.
+        // - When io.WantCaptureKeyboard is true, do not dispatch keyboard input data to your main application, or clear/overwrite your copy of the keyboard data.
+        // Generally you may always pass all inputs to dear imgui, and hide them from your application based on those two flags.
+        SDL_Event event;
+        while (SDL_PollEvent(&event))
+        {
+            ImGui_ImplSDL3_ProcessEvent(&event);
+            if (event.type == SDL_EVENT_QUIT)
+                done = true;
+            if (event.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED && event.window.windowID == SDL_GetWindowID(window))
+                done = true;
+        }
+        if (SDL_GetWindowFlags(window) & SDL_WINDOW_MINIMIZED)
+        {
+            SDL_Delay(10);
+            continue;
+        }
+
+        // Resize swap chain?
+        int fb_width, fb_height;
+        SDL_GetWindowSize(window, &fb_width, &fb_height);
+        if (fb_width > 0 && fb_height > 0 && (g_SwapChainRebuild || g_MainWindowData.Width != fb_width || g_MainWindowData.Height != fb_height))
+        {
+            ImGui_ImplVulkan_SetMinImageCount(g_MinImageCount);
+            ImGui_ImplVulkanH_CreateOrResizeWindow(g_Instance, g_PhysicalDevice, g_Device, &g_MainWindowData, g_QueueFamily, g_Allocator, fb_width, fb_height, g_MinImageCount);
+            g_MainWindowData.FrameIndex = 0;
+            g_SwapChainRebuild = false;
+        }
+
+        // Start the Dear ImGui frame
+        ImGui_ImplVulkan_NewFrame();
+        ImGui_ImplSDL3_NewFrame();
+        igNewFrame();
+
+        // 1. Show the big demo window (Most of the sample code is in ImGui::ShowDemoWindow()! You can browse its code to learn more about Dear ImGui!).
+        if (show_demo_window)
+            igShowDemoWindow(&show_demo_window);
+
+        // 2. Show a simple window that we create ourselves. We use a Begin/End pair to create a named window.
+        {
+            static float f = 0.0f;
+            static int counter = 0;
+
+            igBegin("Hello, world!", NULL, 0);
+            igText("This is some useful text");
+            igCheckbox("Demo window", &show_demo_window);
+            igCheckbox("Another window", &show_another_window);
+
+            igSliderFloat("Float", &f, 0.0f, 1.0f, "%.3f", 0);
+            igColorEdit3("clear color", (float*)&clear_color, 0);
+
+            ImVec2 buttonSize;
+            buttonSize.x = 0;
+            buttonSize.y = 0;
+            if (igButton("Button", buttonSize))
+              counter++;
+            igSameLine(0.0f, -1.0f);
+            igText("counter = %d", counter);
+
+            igText("Application average %.3f ms/frame (%.1f FPS)",
+                   1000.0f / igGetIO()->Framerate, igGetIO()->Framerate);
+            igEnd();
+        }
+
+        // 3. Show another simple window.
+        if (show_another_window)
+        {
+           igBegin("imgui Another Window", &show_another_window, 0);
+           igText("Hello from imgui");
+           ImVec2 buttonSize;
+           buttonSize.x = 0; buttonSize.y = 0;
+           if (igButton("Close me", buttonSize))
+           {
+               show_another_window = false;
+           }
+           igEnd();
+        }
+
+        // Rendering
+        igRender();
+        ImDrawData* main_draw_data = igGetDrawData();
+        const bool main_is_minimized = (main_draw_data->DisplaySize.x <= 0.0f || main_draw_data->DisplaySize.y <= 0.0f);
+        wd->ClearValue.color.float32[0] = clear_color.x * clear_color.w;
+        wd->ClearValue.color.float32[1] = clear_color.y * clear_color.w;
+        wd->ClearValue.color.float32[2] = clear_color.z * clear_color.w;
+        wd->ClearValue.color.float32[3] = clear_color.w;
+        if (!main_is_minimized)
+            FrameRender(wd, main_draw_data);
+
+        // Update and Render additional Platform Windows
+        if (io->ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
+        {
+            igUpdatePlatformWindows();
+            igRenderPlatformWindowsDefault(NULL, NULL);
+        }
+
+        // Present Main Platform Window
+        if (!main_is_minimized)
+            FramePresent(wd);
+    }
+
+    // Cleanup
+    err = vkDeviceWaitIdle(g_Device);
+    check_vk_result_line(err, __LINE__);
+    ImGui_ImplVulkan_Shutdown();
+    ImGui_ImplSDL3_Shutdown();
+    igDestroyContext(NULL);
+
+    CleanupVulkanWindow();
+    CleanupVulkan();
+
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+
+    return 0;
+}


### PR DESCRIPTION
This adds an SDL3 version of the `example_sdl_vulkan` backend. The project contains an SDL2 Vulkan backend, so I figured this may help anyone trying to use SDL3 instead of SDL2.

The changes are minimal since all I did was to change the dependency from SDL2 to SDL3 with help from the migration guide.

I spent a little bit of time getting this to work, so maybe this can work as an example for others looking to have a similar setup?

If this isn't what you are looking for in a PR, I won't have any hurt feelings if this is closed without discussion. Especially considering that this is almost a copy of `example_sdl_vulkan` with slight changes for SDL3.

Thank you for your project, and thank you for your time in reading this.