### PR TITLE
cpp2ffi: don't let the generated-header test link

### DIFF
--- a/generator/cpp2ffi.lua
+++ b/generator/cpp2ffi.lua
@@ -3476,7 +3476,7 @@ function M.Parser()
 		if COMPILER=="gcc" then
 		local include_cmd = COMPILER=="cl" and [[ /I ]] or [[ -I ]]
 		local extra_includes = include_cmd.." ../../cimgui "
-		local CPRE = COMPILER..[[ -std=c99 -DCIMGUI_DEFINE_ENUMS_AND_STRUCTS -DIMGUI_ENABLE_FREETYPE ]] ..extra_includes.. "./output/"..name..".h"
+		local CPRE = COMPILER..[[ -fsyntax-only -x c -std=c99 -DCIMGUI_DEFINE_ENUMS_AND_STRUCTS -DIMGUI_ENABLE_FREETYPE ]] ..extra_includes.. "./output/"..name..".h"
 		print(CPRE)
 		get_cdefs(CPRE,"name")
 		end


### PR DESCRIPTION
The test at the end of cimgui_generation passes neither -c nor -E, so gcc compiles the .h into a precompiled header and then still tries to link, failing with "undefined reference to main" whenever the toolchain puts something link-ish on the command line (in my case `-Wl` from Julia's BinaryBuilder.jl system). That aborts generation via the assert in get_cdefs.

-fsyntax-only is all this check needs, since only the diagnostics are inspected and the get_cdefs return value is discarded. -x c is needed too, without it gcc 5 stays in precompiled-header mode and fails with "output filename specified twice".

Check was originally added in: https://github.com/cimgui/cimgui/commit/8aaa4b624e73d6bb9d6aa0aca9eead8911b1a423